### PR TITLE
Add option for image and video source to be a url.

### DIFF
--- a/dist/etro-cjs.js
+++ b/dist/etro-cjs.js
@@ -1151,7 +1151,7 @@ function VisualSourceMixin(superclass) {
 var Image = /** @class */ (function (_super) {
     __extends(Image, _super);
     function Image(options) {
-        if (typeof (options.source) == 'string') {
+        if (typeof (options.source) === 'string') {
             var img = document.createElement('img');
             img.src = options.source;
             options.source = img;
@@ -1237,7 +1237,7 @@ var Text = /** @class */ (function (_super) {
 var Video = /** @class */ (function (_super) {
     __extends(Video, _super);
     function Video(options) {
-        if (typeof (options.source) == 'string') {
+        if (typeof (options.source) === 'string') {
             var img = document.createElement('video');
             img.src = options.source;
             options.source = img;

--- a/dist/etro-cjs.js
+++ b/dist/etro-cjs.js
@@ -1150,8 +1150,18 @@ function VisualSourceMixin(superclass) {
 
 var Image = /** @class */ (function (_super) {
     __extends(Image, _super);
-    function Image() {
-        return _super !== null && _super.apply(this, arguments) || this;
+    function Image(options) {
+        if (typeof (options.source) == 'string') {
+            var img = document.createElement('img');
+            try {
+                img.src = options.source;
+                options.source = img;
+            }
+            catch (err) {
+                return _this;
+            }
+        }
+        return _super.call(this, options) || this;
     }
     return Image;
 }(VisualSourceMixin(Visual)));

--- a/dist/etro-cjs.js
+++ b/dist/etro-cjs.js
@@ -1236,8 +1236,13 @@ var Text = /** @class */ (function (_super) {
  */
 var Video = /** @class */ (function (_super) {
     __extends(Video, _super);
-    function Video() {
-        return _super !== null && _super.apply(this, arguments) || this;
+    function Video(options) {
+        if (typeof (options.source) == 'string') {
+            var img = document.createElement('video');
+            img.src = options.source;
+            options.source = img;
+        }
+        return _super.call(this, options) || this;
     }
     return Video;
 }(AudioSourceMixin(VisualSourceMixin(Visual))));

--- a/dist/etro-cjs.js
+++ b/dist/etro-cjs.js
@@ -1153,13 +1153,8 @@ var Image = /** @class */ (function (_super) {
     function Image(options) {
         if (typeof (options.source) == 'string') {
             var img = document.createElement('img');
-            try {
-                img.src = options.source;
-                options.source = img;
-            }
-            catch (err) {
-                return _this;
-            }
+            img.src = options.source;
+            options.source = img;
         }
         return _super.call(this, options) || this;
     }

--- a/dist/etro-iife.js
+++ b/dist/etro-iife.js
@@ -1154,13 +1154,8 @@ var etro = (function () {
         function Image(options) {
             if (typeof (options.source) == 'string') {
                 var img = document.createElement('img');
-                try {
-                    img.src = options.source;
-                    options.source = img;
-                }
-                catch (err) {
-                    return _this;
-                }
+                img.src = options.source;
+                options.source = img;
             }
             return _super.call(this, options) || this;
         }

--- a/dist/etro-iife.js
+++ b/dist/etro-iife.js
@@ -1237,8 +1237,13 @@ var etro = (function () {
      */
     var Video = /** @class */ (function (_super) {
         __extends(Video, _super);
-        function Video() {
-            return _super !== null && _super.apply(this, arguments) || this;
+        function Video(options) {
+            if (typeof (options.source) == 'string') {
+                var img = document.createElement('video');
+                img.src = options.source;
+                options.source = img;
+            }
+            return _super.call(this, options) || this;
         }
         return Video;
     }(AudioSourceMixin(VisualSourceMixin(Visual))));

--- a/dist/etro-iife.js
+++ b/dist/etro-iife.js
@@ -1151,8 +1151,18 @@ var etro = (function () {
 
     var Image = /** @class */ (function (_super) {
         __extends(Image, _super);
-        function Image() {
-            return _super !== null && _super.apply(this, arguments) || this;
+        function Image(options) {
+            if (typeof (options.source) == 'string') {
+                var img = document.createElement('img');
+                try {
+                    img.src = options.source;
+                    options.source = img;
+                }
+                catch (err) {
+                    return _this;
+                }
+            }
+            return _super.call(this, options) || this;
         }
         return Image;
     }(VisualSourceMixin(Visual)));

--- a/dist/etro-iife.js
+++ b/dist/etro-iife.js
@@ -1152,7 +1152,7 @@ var etro = (function () {
     var Image = /** @class */ (function (_super) {
         __extends(Image, _super);
         function Image(options) {
-            if (typeof (options.source) == 'string') {
+            if (typeof (options.source) === 'string') {
                 var img = document.createElement('img');
                 img.src = options.source;
                 options.source = img;
@@ -1238,7 +1238,7 @@ var etro = (function () {
     var Video = /** @class */ (function (_super) {
         __extends(Video, _super);
         function Video(options) {
-            if (typeof (options.source) == 'string') {
+            if (typeof (options.source) === 'string') {
                 var img = document.createElement('video');
                 img.src = options.source;
                 options.source = img;

--- a/dist/layer/image.d.ts
+++ b/dist/layer/image.d.ts
@@ -2,5 +2,6 @@ import { VisualSourceOptions } from './visual-source';
 declare type ImageOptions = VisualSourceOptions;
 declare const Image_base: new (...args: unknown[]) => import("./visual-source").VisualSource;
 declare class Image extends Image_base {
+    constructor(options: ImageOptions);
 }
 export { Image, ImageOptions };

--- a/dist/layer/video.d.ts
+++ b/dist/layer/video.d.ts
@@ -7,5 +7,6 @@ declare const Video_base: new (...args: unknown[]) => import("./audio-source").A
  * @extends VisualSource
  */
 declare class Video extends Video_base {
+    constructor(options: VisualSourceOptions);
 }
 export { Video, VideoOptions };

--- a/dist/layer/visual-source.d.ts
+++ b/dist/layer/visual-source.d.ts
@@ -21,7 +21,7 @@ interface VisualSource extends Visual {
     destHeight: Dynamic<number>;
 }
 interface VisualSourceOptions extends VisualOptions {
-    source: HTMLImageElement | HTMLVideoElement;
+    source: HTMLImageElement | HTMLVideoElement | string;
     /** What part of {@link source} to render */
     sourceX?: Dynamic<number>;
     /** What part of {@link source} to render */

--- a/examples/introduction/hello-world2.html
+++ b/examples/introduction/hello-world2.html
@@ -21,8 +21,8 @@
         // add a video layer at 0s in the timeline
           .addLayer(new etro.layer.Video({ startTime: 0, source: video }))
         // add an image layer using a URL as its source
-          .addLayer(new etro.layer.Image({ 
-            startTime: 0, 
+          .addLayer(new etro.layer.Image({
+            startTime: 0,
             source: 'https://pvanderlaat.com/clubfinity.png'
           }))
           .play()

--- a/examples/introduction/hello-world2.html
+++ b/examples/introduction/hello-world2.html
@@ -20,6 +20,11 @@
         movie
         // add a video layer at 0s in the timeline
           .addLayer(new etro.layer.Video({ startTime: 0, source: video }))
+        // add an image layer using a URL as its source
+          .addLayer(new etro.layer.Image({ 
+            startTime: 0, 
+            source: 'https://pvanderlaat.com/clubfinity.png'
+          }))
           .play()
 
         // FOR TESTING issue#8 (don't delete):

--- a/spec/unit/layer/visual-source.spec.ts
+++ b/spec/unit/layer/visual-source.spec.ts
@@ -1,4 +1,6 @@
 import etro from '../../../src/index'
+import { mockAudioContext, mockCanvas } from '../mocks/dom'
+import { mockBaseLayer } from '../mocks/layer'
 import { mockMovie } from '../mocks/movie'
 
 describe('Unit Tests ->', function () {
@@ -31,6 +33,45 @@ describe('Unit Tests ->', function () {
       it('should not be ready when source is not ready', function () {
         source.readyState = 0
         expect(layer.ready).toBe(false)
+      })
+
+      it('should be able to use an image url', async function() {
+        let movie2 = new etro.Movie({
+          actx: mockAudioContext(),
+          canvas: mockCanvas(),
+          autoRefresh: false
+        })
+        movie2.addLayer(mockBaseLayer())
+
+        
+        const tempLayer = new etro.layer.Image({ startTime: 0, duration: 0.8, source: 'https://pvanderlaat.com/clubfinity.png' })
+        const tempImage = new Image()
+        tempImage.src = 'https://pvanderlaat.com/clubfinity.png'
+        movie2.addLayer(tempLayer)
+        // tempLayer.source.readyState = 0
+        expect(tempLayer.source).toEqual(tempImage)
+        let res = await movie2.play()
+        console.log("VANDELY2")
+        console.log(res)
+      })
+      it('shouldn\'t be able to use an invalaid image url', async function() {
+        let movie2 = new etro.Movie({
+          actx: mockAudioContext(),
+          canvas: mockCanvas(),
+          autoRefresh: false
+        })
+        movie2.addLayer(mockBaseLayer())
+
+        
+        const tempLayer = new etro.layer.Image({ startTime: 0, duration: 0.8, source: 'invalid_url_!!!' })
+        // const tempImage = new Image()
+        // tempImage.src = 'not_a_working_url'
+        movie2.addLayer(tempLayer)
+        // tempLayer.source.readyState = 0
+        // expect(tempLayer.source).toEqual(tempImage)
+        let res = await movie2.play()
+        console.log("VANDELY2")
+        console.log(res)
       })
     })
   })

--- a/spec/unit/layer/visual-source.spec.ts
+++ b/spec/unit/layer/visual-source.spec.ts
@@ -1,5 +1,4 @@
 import etro from '../../../src/index'
-import { mockAudioContext, mockCanvas } from '../mocks/dom'
 import { mockBaseLayer } from '../mocks/layer'
 import { mockMovie } from '../mocks/movie'
 
@@ -34,7 +33,7 @@ describe('Unit Tests ->', function () {
         source.readyState = 0
         expect(layer.ready).toBe(false)
       })
-      it('should be able to use an image url', async function() {
+      it('should be able to use an image url', async function () {
         movie.addLayer(mockBaseLayer())
         const tempLayer = new etro.layer.Image({ startTime: 0, duration: 0.8, source: 'https://pvanderlaat.com/clubfinity.png' })
         const tempImage = new Image()

--- a/spec/unit/layer/visual-source.spec.ts
+++ b/spec/unit/layer/visual-source.spec.ts
@@ -34,44 +34,13 @@ describe('Unit Tests ->', function () {
         source.readyState = 0
         expect(layer.ready).toBe(false)
       })
-
       it('should be able to use an image url', async function() {
-        let movie2 = new etro.Movie({
-          actx: mockAudioContext(),
-          canvas: mockCanvas(),
-          autoRefresh: false
-        })
-        movie2.addLayer(mockBaseLayer())
-
-        
+        movie.addLayer(mockBaseLayer())
         const tempLayer = new etro.layer.Image({ startTime: 0, duration: 0.8, source: 'https://pvanderlaat.com/clubfinity.png' })
         const tempImage = new Image()
         tempImage.src = 'https://pvanderlaat.com/clubfinity.png'
-        movie2.addLayer(tempLayer)
-        // tempLayer.source.readyState = 0
+        movie.addLayer(tempLayer)
         expect(tempLayer.source).toEqual(tempImage)
-        let res = await movie2.play()
-        console.log("VANDELY2")
-        console.log(res)
-      })
-      it('shouldn\'t be able to use an invalaid image url', async function() {
-        let movie2 = new etro.Movie({
-          actx: mockAudioContext(),
-          canvas: mockCanvas(),
-          autoRefresh: false
-        })
-        movie2.addLayer(mockBaseLayer())
-
-        
-        const tempLayer = new etro.layer.Image({ startTime: 0, duration: 0.8, source: 'invalid_url_!!!' })
-        // const tempImage = new Image()
-        // tempImage.src = 'not_a_working_url'
-        movie2.addLayer(tempLayer)
-        // tempLayer.source.readyState = 0
-        // expect(tempLayer.source).toEqual(tempImage)
-        let res = await movie2.play()
-        console.log("VANDELY2")
-        console.log(res)
       })
     })
   })

--- a/src/layer/image.ts
+++ b/src/layer/image.ts
@@ -3,6 +3,20 @@ import { VisualSourceMixin, VisualSourceOptions } from './visual-source'
 
 type ImageOptions = VisualSourceOptions
 
-class Image extends VisualSourceMixin(Visual) {}
+class Image extends VisualSourceMixin(Visual) {
+    constructor (options: ImageOptions) {
+        if (typeof(options.source) == 'string') {
+            const img = document.createElement('img')
+            try {
+                img.src = options.source
+                options.source = img
+            }
+            catch (err) {
+                return
+            }
+        }
+        super(options)
+      }
+}
 
 export { Image, ImageOptions }

--- a/src/layer/image.ts
+++ b/src/layer/image.ts
@@ -4,14 +4,14 @@ import { VisualSourceMixin, VisualSourceOptions } from './visual-source'
 type ImageOptions = VisualSourceOptions
 
 class Image extends VisualSourceMixin(Visual) {
-    constructor (options: ImageOptions) {
-        if (typeof(options.source) == 'string') {
-            const img = document.createElement('img')
-            img.src = options.source
-            options.source = img
-        }
-        super(options)
+  constructor (options: ImageOptions) {
+    if (typeof (options.source) === 'string') {
+      const img = document.createElement('img')
+      img.src = options.source
+      options.source = img
     }
+    super(options)
+  }
 }
 
 export { Image, ImageOptions }

--- a/src/layer/image.ts
+++ b/src/layer/image.ts
@@ -7,13 +7,8 @@ class Image extends VisualSourceMixin(Visual) {
     constructor (options: ImageOptions) {
         if (typeof(options.source) == 'string') {
             const img = document.createElement('img')
-            try {
-                img.src = options.source
-                options.source = img
-            }
-            catch (err) {
-                return
-            }
+            img.src = options.source
+            options.source = img
         }
         super(options)
       }

--- a/src/layer/image.ts
+++ b/src/layer/image.ts
@@ -11,7 +11,7 @@ class Image extends VisualSourceMixin(Visual) {
             options.source = img
         }
         super(options)
-      }
+    }
 }
 
 export { Image, ImageOptions }

--- a/src/layer/video.ts
+++ b/src/layer/video.ts
@@ -11,14 +11,14 @@ type VideoOptions = VisualSourceOptions & AudioSourceOptions
  * @extends VisualSource
  */
 class Video extends AudioSourceMixin(VisualSourceMixin(Visual)) {
-    constructor (options: VisualSourceOptions) {
-        if (typeof(options.source) == 'string') {
-            const img = document.createElement('video')
-            img.src = options.source
-            options.source = img
-        }
-        super(options)
-      }
+  constructor (options: VisualSourceOptions) {
+    if (typeof (options.source) === 'string') {
+      const img = document.createElement('video')
+      img.src = options.source
+      options.source = img
+    }
+    super(options)
+  }
 }
 
 export { Video, VideoOptions }

--- a/src/layer/video.ts
+++ b/src/layer/video.ts
@@ -10,6 +10,15 @@ type VideoOptions = VisualSourceOptions & AudioSourceOptions
  * @extends AudioSource
  * @extends VisualSource
  */
-class Video extends AudioSourceMixin(VisualSourceMixin(Visual)) {}
+class Video extends AudioSourceMixin(VisualSourceMixin(Visual)) {
+    constructor (options: VisualSourceOptions) {
+        if (typeof(options.source) == 'string') {
+            const img = document.createElement('video')
+            img.src = options.source
+            options.source = img
+        }
+        super(options)
+      }
+}
 
 export { Video, VideoOptions }

--- a/src/layer/visual-source.ts
+++ b/src/layer/visual-source.ts
@@ -25,7 +25,7 @@ interface VisualSource extends Visual {
 }
 
 interface VisualSourceOptions extends VisualOptions {
-  source: HTMLImageElement | HTMLVideoElement
+  source: HTMLImageElement | HTMLVideoElement | string
   /** What part of {@link source} to render */
   sourceX?: Dynamic<number>
   /** What part of {@link source} to render */


### PR DESCRIPTION
 Solving the first two parts of the following issue by allowing visualsource to accept a string for its "source" and turn it into an HTMLElement('img') or HTMLElement('video'):

https://github.com/etro-js/etro/issues/61