### PR TITLE
:bug: Check that Movie constructor options include all required fields

### DIFF
--- a/src/movie.ts
+++ b/src/movie.ts
@@ -102,6 +102,11 @@ export class Movie {
 
     // Proxy that will be returned by constructor
     const newThis: Movie = watchPublic(this) as Movie
+
+    // Check if required file canvas is provided
+    if (!options.canvas)
+      throw new Error('Required option "canvas" not provided to Movie')
+
     // Set canvas option manually, because it's readonly.
     this._canvas = options.canvas
     delete options.canvas


### PR DESCRIPTION
Etro now throws an error to let the use know that the required field is 
not provided.

Fix for #142 