### PR TITLE
:sparkles: Enforce required options for text layer

### DIFF
--- a/dist/etro-cjs.js
+++ b/dist/etro-cjs.js
@@ -1165,9 +1165,11 @@ var Text = /** @class */ (function (_super) {
     // TODO: is textX necessary? it seems inconsistent, because you can't define
     // width/height directly for a text layer
     function Text(options) {
-        var _this = 
+        var _this = this;
+        if (!options.text)
+            throw new Error('Property "text" is required in TextOptions');
         // Default to no (transparent) background
-        _super.call(this, __assign({ background: null }, options)) || this;
+        _this = _super.call(this, __assign({ background: null }, options)) || this;
         applyOptions(options, _this);
         return _this;
         // this._prevText = undefined;

--- a/dist/etro-iife.js
+++ b/dist/etro-iife.js
@@ -1166,9 +1166,11 @@ var etro = (function () {
         // TODO: is textX necessary? it seems inconsistent, because you can't define
         // width/height directly for a text layer
         function Text(options) {
-            var _this = 
+            var _this = this;
+            if (!options.text)
+                throw new Error('Property "text" is required in TextOptions');
             // Default to no (transparent) background
-            _super.call(this, __assign({ background: null }, options)) || this;
+            _this = _super.call(this, __assign({ background: null }, options)) || this;
             applyOptions(options, _this);
             return _this;
             // this._prevText = undefined;

--- a/src/layer/text.ts
+++ b/src/layer/text.ts
@@ -61,6 +61,9 @@ class Text extends Visual {
   // TODO: is textX necessary? it seems inconsistent, because you can't define
   // width/height directly for a text layer
   constructor (options: TextOptions) {
+    if (!options.text)
+      throw new Error('Property "text" is required in TextOptions')
+
     // Default to no (transparent) background
     super({ background: null, ...options })
     applyOptions(options, this)


### PR DESCRIPTION
Added required check for text layer. I wanted to add a test but was not sure if its the way you work. Would love to add a test if you could assist me. Looking forward for your feedback.

fixes https://github.com/etro-js/etro/issues/146