### PR TITLE
:sparkles: Enforce required options for VisualSourceMixin

### DIFF
--- a/dist/etro-cjs.js
+++ b/dist/etro-cjs.js
@@ -1067,7 +1067,10 @@ function VisualSourceMixin(superclass) {
     var MixedVisualSource = /** @class */ (function (_super) {
         __extends(MixedVisualSource, _super);
         function MixedVisualSource(options) {
-            var _this = _super.call(this, options) || this;
+            var _this = this;
+            if (!options.source)
+                throw new Error('Property "source" is required in options');
+            _this = _super.call(this, options) || this;
             applyOptions(options, _this);
             return _this;
         }

--- a/dist/etro-cjs.js
+++ b/dist/etro-cjs.js
@@ -1165,9 +1165,11 @@ var Text = /** @class */ (function (_super) {
     // TODO: is textX necessary? it seems inconsistent, because you can't define
     // width/height directly for a text layer
     function Text(options) {
-        var _this = 
+        var _this = this;
+        if (!options.text)
+            throw new Error('Property "text" is required in TextOptions');
         // Default to no (transparent) background
-        _super.call(this, __assign({ background: null }, options)) || this;
+        _this = _super.call(this, __assign({ background: null }, options)) || this;
         applyOptions(options, _this);
         return _this;
         // this._prevText = undefined;

--- a/dist/etro-iife.js
+++ b/dist/etro-iife.js
@@ -1166,9 +1166,11 @@ var etro = (function () {
         // TODO: is textX necessary? it seems inconsistent, because you can't define
         // width/height directly for a text layer
         function Text(options) {
-            var _this = 
+            var _this = this;
+            if (!options.text)
+                throw new Error('Property "text" is required in TextOptions');
             // Default to no (transparent) background
-            _super.call(this, __assign({ background: null }, options)) || this;
+            _this = _super.call(this, __assign({ background: null }, options)) || this;
             applyOptions(options, _this);
             return _this;
             // this._prevText = undefined;

--- a/dist/etro-iife.js
+++ b/dist/etro-iife.js
@@ -1068,7 +1068,10 @@ var etro = (function () {
         var MixedVisualSource = /** @class */ (function (_super) {
             __extends(MixedVisualSource, _super);
             function MixedVisualSource(options) {
-                var _this = _super.call(this, options) || this;
+                var _this = this;
+                if (!options.source)
+                    throw new Error('Property "source" is required in options');
+                _this = _super.call(this, options) || this;
                 applyOptions(options, _this);
                 return _this;
             }

--- a/src/layer/text.ts
+++ b/src/layer/text.ts
@@ -61,6 +61,9 @@ class Text extends Visual {
   // TODO: is textX necessary? it seems inconsistent, because you can't define
   // width/height directly for a text layer
   constructor (options: TextOptions) {
+    if (!options.text)
+      throw new Error('Property "text" is required in TextOptions')
+
     // Default to no (transparent) background
     super({ background: null, ...options })
     applyOptions(options, this)

--- a/src/layer/visual-source.ts
+++ b/src/layer/visual-source.ts
@@ -75,6 +75,9 @@ function VisualSourceMixin<OptionsSuperclass extends VisualOptions> (superclass:
     destHeight: Dynamic<number>
 
     constructor (options: MixedVisualSourceOptions) {
+      if (!options.source)
+        throw new Error('Property "source" is required in options')
+
       super(options)
       applyOptions(options, this)
     }


### PR DESCRIPTION
Added required check for VisualSourceMixin. Would love to add a test if you could assist me. Looking forward for your feedback.

fixes https://github.com/etro-js/etro/issues/145