### PR TITLE
:sparkles: Wait to start playing or rendering until movie is ready

### DIFF
--- a/src/movie.ts
+++ b/src/movie.ts
@@ -237,6 +237,12 @@ export class Movie {
       if (!this.paused)
         throw new Error('Already playing')
 
+      if (!this.ready)
+        // we keep waiting until the movie is ready
+        while (true)
+          if (this.ready)
+            break
+
       this._paused = this._ended = false
       this._lastPlayed = performance.now()
       this._lastPlayedOffset = this.currentTime


### PR DESCRIPTION
I cant seem to fix the tests. Linter complains that I cant have an async Promise resolver. If I dont use a Promise inside the play promise, the tests are green. I wanted to use the `_waitForReady` as a Promise because it makes the code readable and it would wait 100 ms for the next retry. Without a Promise the only option I can think of is a while loop. Let me know what you think about the issue. 
Fixes  #149 