### PR TITLE
Fix seek incorrect time and audio error

### DIFF
--- a/src/layer/audio-source.ts
+++ b/src/layer/audio-source.ts
@@ -152,7 +152,12 @@ function AudioSourceMixin<OptionsSuperclass extends BaseOptions> (superclass: Co
     seek (time: number): void {
       super.seek(time)
 
-      this.source.currentTime = this.currentTime + this.sourceStartTime
+      if (this.currentTime !== undefined) {
+        this.source.currentTime = this.currentTime + this.sourceStartTime
+      } else {
+        this.source.currentTime = this.sourceStartTime
+        this.source.pause()
+      }
     }
 
     render () {

--- a/src/layer/base.ts
+++ b/src/layer/base.ts
@@ -138,6 +138,9 @@ class Base implements EtroObject {
    */
   seek (time: number): void {
     this._currentTime = time
+    if (!this._currentTime) {
+      this.active = false
+    }
   }
 
   /**

--- a/src/movie/movie.ts
+++ b/src/movie/movie.ts
@@ -726,6 +726,11 @@ export class Movie {
    * @param time - The new playback position (in seconds)
    */
   seek (time: number) {
+    let isPlaying = false
+    if (!this.paused) {
+      this.pause()
+      isPlaying = true
+    }
     this._currentTime = time
 
     // Call `seek` on every layer
@@ -739,6 +744,10 @@ export class Movie {
           layer.seek(undefined)
         }
       }
+    }
+
+    if (isPlaying) {
+      this.play()
     }
 
     // For backwards compatibility, publish a `seek` event


### PR DESCRIPTION
I made a change in `audio-source.ts` to make sure that `this.source.currentTime` is not passed a `NaN` value to try to avoid the TypeError brought up in #212 .

In `movie.ts`, I added a few lines to pause and unpause a playing movie prior to assigning a new `currentTime` value because I found that otherwise it would often show one frame at the desired seek timestamp and then immediately jump back to where it was prior to me calling seek.