### PR TITLE
Only seek the audio source when the seek time is a number

### DIFF
--- a/src/layer/audio-source.ts
+++ b/src/layer/audio-source.ts
@@ -152,7 +152,11 @@ function AudioSourceMixin<OptionsSuperclass extends BaseOptions> (superclass: Co
     seek (time: number): void {
       super.seek(time)
 
-      this.source.currentTime = this.currentTime + this.sourceStartTime
+      if (isNaN(this.currentTime)) {
+        this.source.currentTime = this.sourceStartTime
+      } else {
+        this.source.currentTime = this.currentTime + this.sourceStartTime
+      }
     }
 
     render () {


### PR DESCRIPTION
This is to fix the bug in #212.