### PR TITLE
Type `KeyFrame.value` as `(number|T)[][]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ npm start
 Now you can open any example (such as
 http://127.0.0.1:8080/examples/introduction/hello-world1.html).
 
+_Running `npm i` may fail depending on your architecture - you may need to install the `node-canvas` [compilation dependencies](https://github.com/Automattic/node-canvas)._
+
 ## Further Reading
 
 - [Documentation](https://etrojs.dev/docs/intro)

--- a/README.md
+++ b/README.md
@@ -90,8 +90,6 @@ npm start
 Now you can open any example (such as
 http://127.0.0.1:8080/examples/introduction/hello-world1.html).
 
-_Running `npm i` may fail depending on your architecture - you may need to install the `node-canvas` [compilation dependencies](https://github.com/Automattic/node-canvas)._
-
 ## Further Reading
 
 - [Documentation](https://etrojs.dev/docs/intro)

--- a/src/util.ts
+++ b/src/util.ts
@@ -91,6 +91,13 @@ export function clearCachedValues (movie: Movie): void {
   valCache.delete(movie)
 }
 
+type InterpolateType = <U = number | object>(
+  startValue: U,
+  endValue: U,
+  percentProgress: number,
+  interpolationKeys: string[]
+) => U
+
 /**
  * A keyframe set.
  *
@@ -101,7 +108,7 @@ export function clearCachedValues (movie: Movie): void {
  * TypeScript users need to specify the type of the value as a type parameter.
  */
 export class KeyFrame<T> {
-  value: (number|T)[][]
+  value: (number|T|InterpolateType)[][]
   /** Keys to interpolate, or all keys if undefined */
   interpolationKeys: string[]
 
@@ -133,8 +140,10 @@ export class KeyFrame<T> {
     for (let i = 0; i < this.value.length; i++) {
       const startTime = this.value[i][0] as number
       const startValue = this.value[i][1] as T
-      type interpolateType = <U = number | object>(startValue: U, endValue: U, percentProgress: number, interpolationKeys: string[]) => U // eslint-disable-line @typescript-eslint/ban-types
-      const interpolate = this.value[i].length === 3 ? this.value[i][2] as unknown as interpolateType : linearInterp
+      const interpolate =
+        this.value[i].length === 3
+          ? (this.value[i][2] as InterpolateType)
+          : linearInterp
       if (i + 1 < this.value.length) {
         const endTime = this.value[i + 1][0] as number
         const endValue = this.value[i + 1][1] as T

--- a/src/util.ts
+++ b/src/util.ts
@@ -101,7 +101,7 @@ export function clearCachedValues (movie: Movie): void {
  * TypeScript users need to specify the type of the value as a type parameter.
  */
 export class KeyFrame<T> {
-  value: unknown[][]
+  value: (number|T)[][]
   /** Keys to interpolate, or all keys if undefined */
   interpolationKeys: string[]
 
@@ -134,7 +134,7 @@ export class KeyFrame<T> {
       const startTime = this.value[i][0] as number
       const startValue = this.value[i][1] as T
       type interpolateType = <U = number | object>(startValue: U, endValue: U, percentProgress: number, interpolationKeys: string[]) => U // eslint-disable-line @typescript-eslint/ban-types
-      const interpolate = this.value[i].length === 3 ? this.value[i][2] as interpolateType : linearInterp
+      const interpolate = this.value[i].length === 3 ? this.value[i][2] as unknown as interpolateType : linearInterp
       if (i + 1 < this.value.length) {
         const endTime = this.value[i + 1][0] as number
         const endValue = this.value[i + 1][1] as T

--- a/src/util.ts
+++ b/src/util.ts
@@ -91,7 +91,7 @@ export function clearCachedValues (movie: Movie): void {
   valCache.delete(movie)
 }
 
-type InterpolateType = <U = number | object>(
+type Interpolate = <U = number | object>(
   startValue: U,
   endValue: U,
   percentProgress: number,
@@ -108,7 +108,7 @@ type InterpolateType = <U = number | object>(
  * TypeScript users need to specify the type of the value as a type parameter.
  */
 export class KeyFrame<T> {
-  value: (number|T|InterpolateType)[][]
+  value: (number|T|Interpolate)[][]
   /** Keys to interpolate, or all keys if undefined */
   interpolationKeys: string[]
 
@@ -142,7 +142,7 @@ export class KeyFrame<T> {
       const startValue = this.value[i][1] as T
       const interpolate =
         this.value[i].length === 3
-          ? (this.value[i][2] as InterpolateType)
+          ? (this.value[i][2] as Interpolate)
           : linearInterp
       if (i + 1 < this.value.length) {
         const endTime = this.value[i + 1][0] as number


### PR DESCRIPTION
## Description
This PR implements https://github.com/etro-js/etro/issues/256

### Caveats
- `interpolateType` only supports `number | object` so unless we update its type, we cannot avoid using `as unknown` cast.