### PR TITLE
:sparkles: Added optional onDraw method to `play` to run after the _render call.

### DIFF
--- a/spec/unit/movie/movie.spec.ts
+++ b/spec/unit/movie/movie.spec.ts
@@ -130,6 +130,24 @@ describe('Unit Tests ->', function () {
         expect(layer.stop).toHaveBeenCalledTimes(0)
       })
 
+      it('should call user provided `onDraw` after drawing', async function () {
+        // 1a. Force currentTime to 0
+        mockTime(0)
+
+        // 1b. Layer must be inactive to start
+        const layer = movie.layers[0]
+        layer.active = false
+
+        // 2a. Prepare options object with onDraw callback
+        const options = jasmine.createSpyObj('options', ['onDraw'])
+
+        // 2. Play one frame at the beginning of the movie with the spy options
+        await movie.play(options)
+
+        // 3. Make sure onDraw was called
+        expect(options.onDraw).toHaveBeenCalledTimes(1)
+      })
+
       it('should be able to operate after a layer has been deleted', async function () {
         mockTime()
 

--- a/spec/unit/movie/movie.spec.ts
+++ b/spec/unit/movie/movie.spec.ts
@@ -130,24 +130,6 @@ describe('Unit Tests ->', function () {
         expect(layer.stop).toHaveBeenCalledTimes(0)
       })
 
-      it('should call user provided `onDraw` after drawing', async function () {
-        // 1a. Force currentTime to 0
-        mockTime(0)
-
-        // 1b. Layer must be inactive to start
-        const layer = movie.layers[0]
-        layer.active = false
-
-        // 2a. Prepare options object with onDraw callback
-        const options = jasmine.createSpyObj('options', ['onDraw'])
-
-        // 2b. Play one frame at the beginning of the movie with the spy options
-        await movie.play(options)
-
-        // 3. Make sure onDraw was called
-        expect(options.onDraw).toHaveBeenCalledTimes(1)
-      })
-
       it('should be able to operate after a layer has been deleted', async function () {
         mockTime()
 
@@ -291,6 +273,28 @@ describe('Unit Tests ->', function () {
             expect(movie.currentTime).toBe(0)
           }
         })
+      })
+
+      it('should call user provided `onDraw` after drawing', async function () {
+        mockTime(0, 500)
+
+        // Prepare options object with onDraw callback
+        let callCount = 0
+        await movie.play({
+          onStart: () => {
+            // The call count should be 0 at the start
+            expect(callCount).toBe(0)
+            expect(movie.currentTime).toBe(0)
+          },
+          onDraw: () => {
+            // Set the step to be 500 ms
+            // So we expect the currentTime to be 0.5 after the first draw
+            expect(movie.currentTime).toBe(0.5)
+            callCount++
+          }
+        })
+        // The call count should be 1 at the end
+        expect(callCount).toBe(1)
       })
 
       it('should have an active stream while streaming', async function () {

--- a/spec/unit/movie/movie.spec.ts
+++ b/spec/unit/movie/movie.spec.ts
@@ -141,7 +141,7 @@ describe('Unit Tests ->', function () {
         // 2a. Prepare options object with onDraw callback
         const options = jasmine.createSpyObj('options', ['onDraw'])
 
-        // 2. Play one frame at the beginning of the movie with the spy options
+        // 2b. Play one frame at the beginning of the movie with the spy options
         await movie.play(options)
 
         // 3. Make sure onDraw was called

--- a/src/movie/movie.ts
+++ b/src/movie/movie.ts
@@ -153,11 +153,7 @@ export class Movie {
     await new Promise<void>(resolve => {
       if (!this.renderingFrame) {
         // Not rendering (and not playing), so play.
-        this._render(undefined, () => {
-          // Call optional onDraw callback when render is complete
-          options.onDraw?.()
-          return resolve()
-        })
+        this._render(undefined, resolve, options.onDraw)
       }
 
       // Stop rendering frame if currently doing so, because playing has higher
@@ -404,10 +400,10 @@ export class Movie {
    * Processes one frame of the movie and draws it to the canvas
    *
    * @param [timestamp=performance.now()]
-   * @param [done=undefined] - Called when done playing or when the current
-   * frame is loaded
+   * @param [done=undefined] - Called when done playing or when the current frame is loaded
+   * @param [onFrameRender=undefined] - Called when the current frame is rendered
    */
-  private _render (timestamp = performance.now(), done = undefined) {
+  private _render (timestamp = performance.now(), done = undefined, onFrameRender = undefined) {
     clearCachedValues(this)
 
     if (!this.rendering) {
@@ -487,6 +483,7 @@ export class Movie {
       this._renderBackground(timestamp)
       this._renderLayers()
       this._applyEffects()
+      onFrameRender?.()
     } else {
       // If we are recording, pause the media recorder until the movie is
       // ready.

--- a/src/movie/movie.ts
+++ b/src/movie/movie.ts
@@ -124,9 +124,9 @@ export class Movie {
    * Plays the movie
    *
    * @param [options]
+   * @param [options.onDraw] Called when the current frame is drawn to the canvas
    * @param [options.onStart] Called when the movie starts playing
    * @param [options.duration] The duration of the movie to play in seconds
-   *
    * @return Fulfilled when the movie is done playing, never fails
    */
   async play (options: {

--- a/src/movie/movie.ts
+++ b/src/movie/movie.ts
@@ -130,6 +130,7 @@ export class Movie {
    * @return Fulfilled when the movie is done playing, never fails
    */
   async play (options: {
+    onDraw?: () => void,
     onStart?: () => void,
     duration?: number,
   } = {}): Promise<void> {
@@ -152,7 +153,11 @@ export class Movie {
     await new Promise<void>(resolve => {
       if (!this.renderingFrame) {
         // Not rendering (and not playing), so play.
-        this._render(undefined, resolve)
+        this._render(undefined, () => {
+          // Call optional onDraw callback when render is complete
+          options.onDraw?.()
+          return resolve()
+        })
       }
 
       // Stop rendering frame if currently doing so, because playing has higher


### PR DESCRIPTION
## Description
Implements an optional callback that gets run after every `Movie._render()` 

resolves: https://github.com/etro-js/etro/issues/230