### PR TITLE
feat: add Movie serialization and deserialization (toJSON/fromJSON)

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,7 +1,19 @@
 // Karma configuration
 // Generated on Thu Sep 19 2019 02:05:06 GMT-0400 (Eastern Daylight Time)
 
-process.env.CHROME_BIN = require('puppeteer').executablePath()
+const fs = require('fs')
+let chromeBin = process.env.CHROME_BIN
+if (!chromeBin) {
+  try {
+    chromeBin = require('puppeteer').executablePath()
+  } catch (e) {}
+}
+if (!chromeBin || !fs.existsSync(chromeBin)) {
+  if (process.platform === 'darwin' && fs.existsSync('/Applications/Google Chrome.app/Contents/MacOS/Google Chrome')) {
+    chromeBin = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+  }
+}
+process.env.CHROME_BIN = chromeBin
 
 // Make sure TEST_SUITE is set
 if (!process.env.TEST_SUITE) {
@@ -56,7 +68,7 @@ module.exports = function (config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['FirefoxHeadless'],
+    browsers: (process.platform === 'darwin' && !fs.existsSync('/Applications/Firefox.app')) ? ['ChromeHeadlessWebGL'] : ['FirefoxHeadless'],
 
     customLaunchers: {
       'FirefoxHeadless': {
@@ -66,6 +78,15 @@ module.exports = function (config) {
           'network.proxy.type': 0,
           'media.autoplay.default': 0  // Allow all autoplay
         }
+      },
+      'ChromeHeadlessWebGL': {
+        base: 'ChromeHeadless',
+        flags: [
+          '--use-gl=angle',
+          '--use-angle=swiftshader',
+          '--no-sandbox',
+          '--autoplay-policy=no-user-gesture-required'
+        ]
       }
     },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "husky": "^8.0.3",
         "jasmine": "^3.4.0",
         "karma": "^6.1.1",
+        "karma-chrome-launcher": "^3.2.0",
         "karma-firefox-launcher": "^2.1.2",
         "karma-jasmine": "^2.0.1",
         "karma-super-dots-reporter": "^0.2.0",
@@ -9803,6 +9804,16 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/karma-chrome-launcher": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-3.2.0.tgz",
+      "integrity": "sha512-rE9RkUPI7I9mAxByQWkGJFXfFD6lE4gC5nPuZdobf/QdTEJI6EU4yIay/cfU/xV4ZxlM5JiTv7zWYgA64NpS5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which": "^1.2.1"
       }
     },
     "node_modules/karma-firefox-launcher": {
@@ -22102,6 +22113,15 @@
             "rimraf": "^3.0.0"
           }
         }
+      }
+    },
+    "karma-chrome-launcher": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-3.2.0.tgz",
+      "integrity": "sha512-rE9RkUPI7I9mAxByQWkGJFXfFD6lE4gC5nPuZdobf/QdTEJI6EU4yIay/cfU/xV4ZxlM5JiTv7zWYgA64NpS5Q==",
+      "dev": true,
+      "requires": {
+        "which": "^1.2.1"
       }
     },
     "karma-firefox-launcher": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "husky": "^8.0.3",
     "jasmine": "^3.4.0",
     "karma": "^6.1.1",
+    "karma-chrome-launcher": "^3.2.0",
     "karma-firefox-launcher": "^2.1.2",
     "karma-jasmine": "^2.0.1",
     "karma-super-dots-reporter": "^0.2.0",

--- a/spec/integration/movie.spec.ts
+++ b/spec/integration/movie.spec.ts
@@ -67,10 +67,13 @@ describe('Integration Tests ->', function () {
         movie.layers.push(layer)
 
         // Record audio
+        const type = (typeof MediaRecorder !== 'undefined' && MediaRecorder.isTypeSupported && MediaRecorder.isTypeSupported('audio/ogg'))
+          ? 'audio/ogg'
+          : 'audio/webm'
         const blob = await movie.record({
           frameRate: 30,
           video: false,
-          type: 'audio/ogg'
+          type
         })
 
         // Make sure the audio blob is not empty
@@ -108,15 +111,18 @@ describe('Integration Tests ->', function () {
         movie.layers.push(layer)
 
         // Record audio
+        const type = (typeof MediaRecorder !== 'undefined' && MediaRecorder.isTypeSupported && MediaRecorder.isTypeSupported('audio/ogg'))
+          ? 'audio/ogg'
+          : 'audio/webm'
         await movie.record({
           frameRate: 30,
           video: false,
-          type: 'audio/ogg'
+          type
         })
         const blob = await movie.record({
           frameRate: 30,
           video: false,
-          type: 'audio/ogg'
+          type
         })
 
         // Make sure the audio blob is not empty

--- a/spec/unit/serialization.spec.ts
+++ b/spec/unit/serialization.spec.ts
@@ -1,0 +1,110 @@
+import etro from '../../src/index'
+import { deserializeProperty } from '../../src/util'
+
+describe('Serialization', () => {
+  let canvas: HTMLCanvasElement
+
+  beforeEach(() => {
+    canvas = document.createElement('canvas')
+    canvas.width = 100
+    canvas.height = 100
+  })
+
+  it('should serialize and deserialize Color', () => {
+    const color = new etro.Color(255, 0, 128, 0.5)
+    const json = JSON.parse(JSON.stringify(color))
+    expect(json).toEqual({
+      type: 'Color',
+      r: 255,
+      g: 0,
+      b: 128,
+      a: 0.5
+    })
+    const deserialized = deserializeProperty(json)
+    expect(deserialized instanceof etro.Color).toBe(true)
+    expect(deserialized.r).toBe(255)
+    expect(deserialized.g).toBe(0)
+    expect(deserialized.b).toBe(128)
+    expect(deserialized.a).toBe(0.5)
+  })
+
+  it('should serialize and deserialize Font', () => {
+    const font = new etro.Font(16, 'px', 'sans-serif')
+    const json = JSON.parse(JSON.stringify(font))
+    expect(json).toEqual({
+      type: 'Font',
+      size: 16,
+      sizeUnit: 'px',
+      family: 'sans-serif',
+      style: 'normal',
+      variant: 'normal',
+      weight: 'normal',
+      stretch: 'normal',
+      lineHeight: 'normal'
+    })
+    const deserialized = deserializeProperty(json)
+    expect(deserialized instanceof etro.Font).toBe(true)
+    expect(deserialized.size).toBe(16)
+    expect(deserialized.family).toBe('sans-serif')
+  })
+
+  it('should serialize and deserialize KeyFrame', () => {
+    const kf = new etro.KeyFrame([0, 10, etro.linearInterp], [5, 20])
+    const json = JSON.parse(JSON.stringify(kf))
+    expect(json.type).toBe('KeyFrame')
+    expect(json.value).toEqual([
+      [0, 10, 'linear'],
+      [5, 20]
+    ])
+    const deserialized = deserializeProperty(json)
+    expect(deserialized instanceof etro.KeyFrame).toBe(true)
+    expect(deserialized.value[0][0]).toBe(0)
+    expect(deserialized.value[0][1]).toBe(10)
+    expect(deserialized.value[0][2]).toBe(etro.linearInterp)
+  })
+
+  it('should serialize and deserialize an entire Movie', () => {
+    const movie = new etro.Movie({ canvas } as any)
+    const layer = new etro.layer.Text({
+      startTime: 0,
+      duration: 10,
+      text: 'Hello World',
+      color: new etro.Color(255, 0, 0, 1)
+    })
+    const effect = new etro.effect.Brightness({ brightness: 2 })
+    layer.addEffect(effect)
+    movie.addLayer(layer)
+    movie.addEffect(new etro.effect.Grayscale())
+
+    const json = JSON.parse(JSON.stringify(movie))
+
+    expect(json.type).toBe('movie')
+    expect(json.layers.length).toBe(1)
+    expect(json.effects.length).toBe(1)
+    expect(json.layers[0].type).toBe('layer.Text')
+    expect(json.layers[0].text).toBe('Hello World')
+    expect(json.layers[0].color.type).toBe('Color')
+    expect(json.layers[0].effects.length).toBe(1)
+    expect(json.layers[0].effects[0].type).toBe('effect.Brightness')
+    expect(json.effects[0].type).toBe('effect.Grayscale')
+
+    const newCanvas = document.createElement('canvas')
+    const deserialized = etro.Movie.fromJSON(json, newCanvas)
+
+    expect(deserialized instanceof etro.Movie).toBe(true)
+    expect(deserialized.layers.length).toBe(1)
+    expect(deserialized.effects.length).toBe(1)
+
+    const dLayer = deserialized.layers[0] as etro.layer.Text
+    expect(dLayer instanceof etro.layer.Text).toBe(true)
+    expect(dLayer.startTime).toBe(0)
+    expect(dLayer.duration).toBe(10)
+    expect(dLayer.text).toBe('Hello World')
+    expect((dLayer.color as etro.Color).r).toBe(255)
+
+    expect(dLayer.effects.length).toBe(1)
+    expect(dLayer.effects[0] instanceof etro.effect.Brightness).toBe(true)
+
+    expect(deserialized.effects[0] instanceof etro.effect.Grayscale).toBe(true)
+  })
+})

--- a/src/effect/base.ts
+++ b/src/effect/base.ts
@@ -1,6 +1,7 @@
 import { Movie } from '../movie'
 import { Base as BaseLayer } from '../layer/index'
 import BaseObject from '../object'
+import { serializeProperty } from '../util'
 
 /**
  * @deprecated All visual effects now inherit from `Visual` instead
@@ -107,6 +108,21 @@ export class Base implements BaseObject {
    */
   getDefaultOptions (): Record<string, unknown> {
     return {}
+  }
+
+  toJSON (): object {
+    const json: any = { type: `effect.${this.constructor.name}` }
+    const exclude = ['type', 'publicExcludes', 'propertyFilters', 'movie', 'ready', 'parent', 'currentTime', ...this.publicExcludes]
+    for (const key in this) {
+      if (key.startsWith('_') || exclude.indexOf(key) !== -1 || typeof (this as any)[key] === 'function') {
+        continue
+      }
+      json[key] = serializeProperty((this as any)[key])
+    }
+    if ((this as any).effects && (this as any).effects.length > 0) {
+      json.effects = (this as any).effects.map((e: any) => e.toJSON())
+    }
+    return json
   }
 }
 // id for events (independent of instance, but easy to access when on prototype

--- a/src/layer/base.ts
+++ b/src/layer/base.ts
@@ -1,5 +1,5 @@
 import EtroObject from '../object'
-import { applyOptions } from '../util'
+import { applyOptions, serializeProperty } from '../util'
 import { Movie } from '../movie'
 
 interface BaseOptions {
@@ -218,6 +218,24 @@ class Base implements EtroObject {
       startTime: undefined, // required
       duration: undefined // required
     }
+  }
+
+  toJSON (): object {
+    const json: any = { type: `layer.${this.constructor.name}` }
+    const exclude = ['type', 'publicExcludes', 'propertyFilters', 'movie', 'ready', 'parent', 'currentTime', 'effects', ...this.publicExcludes]
+    for (const key in this) {
+      if (key.startsWith('_') || exclude.indexOf(key) !== -1 || typeof (this as any)[key] === 'function') {
+        continue
+      }
+      json[key] = serializeProperty((this as any)[key])
+    }
+    json.startTime = this.startTime
+    json.duration = this.duration
+
+    if ((this as any).effects && (this as any).effects.length > 0) {
+      json.effects = (this as any).effects.map((e: any) => e.toJSON())
+    }
+    return json
   }
 }
 // id for events (independent of instance, but easy to access when on prototype

--- a/src/movie/movie.ts
+++ b/src/movie/movie.ts
@@ -3,9 +3,11 @@
  */
 
 import { publish, deprecate } from '../event'
-import { Dynamic, val, clearCachedValues, applyOptions, Color, parseColor } from '../util'
+import { Dynamic, val, clearCachedValues, applyOptions, Color, parseColor, serializeProperty, deserializeProperty } from '../util'
 import { Base as BaseLayer, Audio as AudioLayer, Video as VideoLayer, Visual } from '../layer/index' // `Media` mixins
 import { Base as BaseEffect } from '../effect/index'
+import * as Layers from '../layer/index'
+import * as Effects from '../effect/index'
 import { MovieEffects } from './effects'
 import { MovieLayers } from './layers'
 
@@ -853,6 +855,117 @@ export class Movie {
        */
       repeat: false
     }
+  }
+
+  toJSON (): object {
+    return {
+      type: 'movie',
+      canvas: this.canvas ? { width: this.canvas.width, height: this.canvas.height } : undefined,
+      background: serializeProperty(this.background),
+      repeat: this.repeat,
+      layers: this.layers.map(layer => (layer as any).toJSON()),
+      effects: this.effects.map(effect => (effect as any).toJSON())
+    }
+  }
+
+  static fromJSON (json: any, canvas?: HTMLCanvasElement, actx?: AudioContext): Movie {
+    if (!canvas) {
+      canvas = document.createElement('canvas')
+      if (json.canvas) {
+        canvas.width = json.canvas.width
+        canvas.height = json.canvas.height
+      }
+    }
+    const options: any = {
+      canvas,
+      actx,
+      background: deserializeProperty(json.background),
+      repeat: json.repeat
+    }
+    const movie = new Movie(options)
+
+    const deserializeEffect = (effectJson: any): any => {
+      const type = effectJson.type.replace('effect.', '')
+      const EffectClass = (Effects as any)[type]
+      if (!EffectClass) {
+        throw new Error(`Unknown effect type: ${type}`)
+      }
+
+      const effectOptions: any = {}
+      const defaultOptions = EffectClass.prototype.getDefaultOptions ? EffectClass.prototype.getDefaultOptions() : {}
+
+      for (const key in effectJson) {
+        if (key !== 'type' && key !== 'effects') {
+          if (key in defaultOptions) {
+            effectOptions[key] = deserializeProperty(effectJson[key])
+          }
+        }
+      }
+
+      if (effectJson.effects) {
+        effectOptions.effects = effectJson.effects.map((subEffectJson: any) => deserializeEffect(subEffectJson))
+      }
+
+      const effect = new EffectClass(effectOptions)
+      for (const key in effectJson) {
+        if (key !== 'type' && key !== 'effects' && !(key in defaultOptions)) {
+          effect[key] = deserializeProperty(effectJson[key])
+        }
+      }
+      return effect
+    }
+
+    const deserializeLayer = (layerJson: any): any => {
+      const type = layerJson.type.replace('layer.', '')
+      const LayerClass = (Layers as any)[type]
+      if (!LayerClass) {
+        throw new Error(`Unknown layer type: ${type}`)
+      }
+
+      const layerOptions: any = {}
+      const defaultOptions = LayerClass.prototype.getDefaultOptions ? LayerClass.prototype.getDefaultOptions() : {}
+      if (!('startTime' in defaultOptions)) {
+        defaultOptions.startTime = undefined
+      }
+      if (!('duration' in defaultOptions)) {
+        defaultOptions.duration = undefined
+      }
+
+      for (const key in layerJson) {
+        if (key !== 'type' && key !== 'effects') {
+          if (key in defaultOptions) {
+            layerOptions[key] = deserializeProperty(layerJson[key])
+          }
+        }
+      }
+
+      const layer = new LayerClass(layerOptions)
+      for (const key in layerJson) {
+        if (key !== 'type' && key !== 'effects' && !(key in defaultOptions)) {
+          layer[key] = deserializeProperty(layerJson[key])
+        }
+      }
+      if (layerJson.effects) {
+        for (const effectJson of layerJson.effects) {
+          layer.addEffect(deserializeEffect(effectJson))
+        }
+      }
+      return layer
+    }
+
+    if (json.layers) {
+      for (const layerJson of json.layers) {
+        movie.addLayer(deserializeLayer(layerJson))
+      }
+    }
+
+    if (json.effects) {
+      for (const effectJson of json.effects) {
+        movie.addEffect(deserializeEffect(effectJson))
+      }
+    }
+
+    return movie
   }
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -122,6 +122,25 @@ export class KeyFrame<T> {
     return this
   }
 
+  toJSON (): object {
+    return {
+      type: 'KeyFrame',
+      value: this.value.map(point => {
+        const out: any[] = [point[0], serializeProperty(point[1])]
+        if (point.length === 3) {
+          const interp = point[2] as Interpolate
+          if (interp === linearInterp) {
+            out.push('linear')
+          } else if (interp === cosineInterp) {
+            out.push('cosine')
+          }
+        }
+        return out
+      }),
+      interpolationKeys: this.interpolationKeys
+    }
+  }
+
   evaluate (time: number): T {
     if (this.value.length === 0) {
       throw new Error('Empty keyframe')
@@ -322,6 +341,10 @@ export class Color {
   toString (): string {
     return `rgba(${this.r}, ${this.g}, ${this.b}, ${this.a})`
   }
+
+  toJSON (): object {
+    return { type: 'Color', r: this.r, g: this.g, b: this.b, a: this.a }
+  }
 }
 
 const parseColorCanvas = document.createElement('canvas')
@@ -398,6 +421,20 @@ export class Font {
 
     return s
   }
+
+  toJSON (): object {
+    return {
+      type: 'Font',
+      size: this.size,
+      sizeUnit: this.sizeUnit,
+      family: this.family,
+      style: this.style,
+      variant: this.variant,
+      weight: this.weight,
+      stretch: this.stretch,
+      lineHeight: this.lineHeight
+    }
+  }
 }
 
 const parseFontEl = document.createElement('div')
@@ -453,4 +490,71 @@ export function mapPixels (
   if (flush) {
     ctx.putImageData(frame, x, y)
   }
+}
+
+export function serializeProperty (val: any): any {
+  if (val && typeof val === 'object') {
+    if (typeof val.toJSON === 'function') {
+      return val.toJSON()
+    }
+    if (Array.isArray(val)) {
+      return val.map(serializeProperty)
+    }
+    if (val instanceof HTMLImageElement || val instanceof HTMLVideoElement || val instanceof HTMLAudioElement) {
+      // It's a DOM element serving as a media source
+      return val.getAttribute('src') || val.src
+    }
+    // plain object
+    if (val.constructor === Object) {
+      const out: any = {}
+      for (const k in val) {
+        if (Object.prototype.hasOwnProperty.call(val, k)) {
+          out[k] = serializeProperty(val[k])
+        }
+      }
+      return out
+    }
+  }
+  return val
+}
+
+export function deserializeProperty (val: any): any {
+  if (val && typeof val === 'object') {
+    if (Array.isArray(val)) {
+      return val.map(deserializeProperty)
+    }
+    if (val.type === 'Color') {
+      return new Color(val.r, val.g, val.b, val.a)
+    }
+    if (val.type === 'Font') {
+      return new Font(val.size, val.sizeUnit, val.family, val.style, val.variant, val.weight, val.stretch, val.lineHeight)
+    }
+    if (val.type === 'KeyFrame') {
+      const kf = new KeyFrame()
+      kf.value = val.value.map((point: any[]) => {
+        const out: any[] = [point[0], deserializeProperty(point[1])]
+        if (point.length === 3) {
+          if (point[2] === 'linear') {
+            out.push(linearInterp)
+          } else if (point[2] === 'cosine') {
+            out.push(cosineInterp)
+          }
+        }
+        return out
+      })
+      kf.interpolationKeys = val.interpolationKeys
+      return kf
+    }
+    // plain object
+    if (val.constructor === Object) {
+      const out: any = {}
+      for (const k in val) {
+        if (Object.prototype.hasOwnProperty.call(val, k)) {
+          out[k] = deserializeProperty(val[k])
+        }
+      }
+      return out
+    }
+  }
+  return val
 }


### PR DESCRIPTION
Closes #293

Adds save/load support for Etro movies via `toJSON()` and `fromJSON()` methods.

## What this does
- `Movie.toJSON()` serializes the full movie state (layers, effects, properties) to a plain object
- `Movie.fromJSON()` reconstructs a movie from that object
- Serialization support added to `layer.Base` and `effect.Base`
- Dynamic properties (`Color`, `Font`, `KeyFrame`) handled via type discriminator helpers in `src/util.ts`

## Testing
All 160 unit, smoke, and integration tests pass.