### PR TITLE
🔧 Fix ShipJS releases config shape

### DIFF
--- a/ship.config.js
+++ b/ship.config.js
@@ -25,17 +25,15 @@ module.exports = {
     const newChangelog = parsed.toString()
     fs.writeFileSync(changelogFile, newChangelog, 'utf8')
   },
-  releases: [
-    {
-      extractChangelog: ({ version, dir }) => {
-        const changelogFile = `${dir}/CHANGELOG.md`
-        const changelog = fs.readFileSync(changelogFile, 'utf8')
-        const parsed = parser(changelog)
-        const release = parsed.findRelease(version)
-        return `${release.toString()}\n${release.getCompareLink()}`
-      },
-    }
-  ]
+  releases: {
+    extractChangelog: ({ version, dir }) => {
+      const changelogFile = `${dir}/CHANGELOG.md`
+      const changelog = fs.readFileSync(changelogFile, 'utf8')
+      const parsed = parser(changelog)
+      const release = parsed.findRelease(version)
+      return `${release.toString()}\n${release.getCompareLink()}`
+    },
+  }
 }
 
 class Changelog {


### PR DESCRIPTION
## Summary
- change ShipJS releases config from a single-item array to an object
- keep the existing extractChangelog implementation unchanged
- align the config shape with ShipJS so GitHub release notes include the compare link

Fixes #261.

## Validation
- node --check ship.config.js
- git diff --check