### PR TITLE
:zap: Skip redundant per-frame canvas reset on visual layers

### DIFF
--- a/spec/unit/layer/visual.spec.ts
+++ b/spec/unit/layer/visual.spec.ts
@@ -39,6 +39,51 @@ describe('Unit Tests ->', function () {
 
         expect(layer.doRender).toHaveBeenCalledTimes(0)
       })
+
+      describe('canvas resizing ->', function () {
+        beforeEach(function () {
+          layer.width = 100
+          layer.height = 100
+        })
+
+        it('should not reset the rendering context when its dimensions are unchanged', function () {
+          layer.render(0)
+
+          layer.cctx.imageSmoothingEnabled = false
+          layer.render(0)
+
+          expect(layer.canvas.width).toBe(100)
+          expect(layer.canvas.height).toBe(100)
+          expect(layer.cctx.imageSmoothingEnabled).toBe(false)
+        })
+
+        it('should resize its canvas when its dimensions change', function () {
+          layer.render(0)
+          expect(layer.canvas.width).toBe(100)
+
+          layer.width = 150
+          etro.clearCachedValues(layer.movie)
+          layer.render(0)
+
+          expect(layer.canvas.width).toBe(150)
+        })
+      })
+
+      describe('canvas clearing ->', function () {
+        beforeEach(function () {
+          layer.width = 100
+          layer.height = 100
+        })
+
+        it('should clear its canvas on every frame', function () {
+          layer.render(0)
+
+          spyOn(layer.cctx, 'clearRect')
+          layer.render(0)
+
+          expect(layer.cctx.clearRect).toHaveBeenCalled()
+        })
+      })
     })
   })
 })

--- a/src/layer/visual.ts
+++ b/src/layer/visual.ts
@@ -106,8 +106,17 @@ class Visual extends Base {
   }
 
   beginRender (): void {
-    this.canvas.width = val(this, 'width', this.currentTime)
-    this.canvas.height = val(this, 'height', this.currentTime)
+    const width = val(this, 'width', this.currentTime)
+    const height = val(this, 'height', this.currentTime)
+
+    if (this.canvas.width !== width) {
+      this.canvas.width = width
+    }
+    if (this.canvas.height !== height) {
+      this.canvas.height = height
+    }
+
+    this.cctx.clearRect(0, 0, this.canvas.width, this.canvas.height)
     this.cctx.globalAlpha = val(this, 'opacity', this.currentTime)
   }
 


### PR DESCRIPTION
Closes #342.

## Problem
`Visual.beginRender` assigns `canvas.width`/`canvas.height` on every frame. Per
MDN, assigning either resets the rendering context even when the value is
unchanged, so every visual layer pays for a full context reset per frame.

## Change
- Only reassign `canvas.width`/`height` when the dimension actually changes,
  mirroring the guard already used in the `Transform` and `Shader` effects.
- That reassignment was previously the only thing clearing the layer canvas
  between frames, so clear it explicitly with `clearRect` each frame.

## Testing
- `npm run test:unit` — passing (added coverage in `spec/unit/layer/visual.spec.ts`)
- `npm run test:smoke` — passing
- `npm run build` — clean