### PR TITLE
:bug: Clear the transform effect's scratch canvas between frames

### DIFF
--- a/spec/unit/effect/transform.spec.ts
+++ b/spec/unit/effect/transform.spec.ts
@@ -1,0 +1,51 @@
+import etro from '../../../src/index'
+import { mockMovie } from '../mocks/movie'
+
+describe('Unit Tests ->', function () {
+  describe('Effects', function () {
+    describe('Transform', function () {
+      let movie
+      let effect
+
+      // Draw a small square in the top left corner of the target, like a layer
+      // would at the start of a frame.
+      function renderFrame (reltime) {
+        movie.cctx.clearRect(0, 0, movie.canvas.width, movie.canvas.height)
+        movie.cctx.fillStyle = 'red'
+        movie.cctx.fillRect(0, 0, 4, 4)
+
+        effect.apply(movie, reltime)
+        etro.clearCachedValues(movie)
+      }
+
+      function alphaAt (x, y) {
+        return movie.cctx.getImageData(x, y, 1, 1).data[3]
+      }
+
+      beforeEach(function () {
+        movie = mockMovie()
+        // The mock canvas is a spy, but this effect composites real pixels
+        movie.canvas = document.createElement('canvas')
+        movie.canvas.width = 20
+        movie.canvas.height = 20
+        movie.cctx = movie.canvas.getContext('2d')
+
+        effect = new etro.effect.Transform({
+          // Move the target 10px to the right over one second
+          matrix: (element, time) =>
+            new etro.effect.Transform.Matrix().translate(10 * time, 0)
+        })
+        effect.tryAttach(movie)
+      })
+
+      it('should not leave the previous frame behind when the matrix changes', function () {
+        renderFrame(0)
+        renderFrame(1)
+
+        // The square should only be at its new position
+        expect(alphaAt(2, 2)).toBe(0)
+        expect(alphaAt(12, 2)).toBeGreaterThan(0)
+      })
+    })
+  })
+})

--- a/src/effect/transform.ts
+++ b/src/effect/transform.ts
@@ -44,6 +44,9 @@ class Transform extends Visual {
       this._tmpCanvas.height = target.canvas.height
     }
 
+    this._tmpCtx.setTransform(1, 0, 0, 1, 0, 0)
+    this._tmpCtx.clearRect(0, 0, this._tmpCanvas.width, this._tmpCanvas.height)
+
     // Use data, since that's the underlying storage
     this._tmpMatrix.data = val(this, 'matrix', reltime).data
 
@@ -52,8 +55,6 @@ class Transform extends Visual {
       this._tmpMatrix.d, this._tmpMatrix.e, this._tmpMatrix.f
     )
     this._tmpCtx.drawImage(target.canvas, 0, 0)
-    // Assume it was identity for now
-    this._tmpCtx.setTransform(1, 0, 0, 0, 1, 0)
     target.cctx.clearRect(0, 0, target.canvas.width, target.canvas.height)
     target.cctx.drawImage(this._tmpCanvas, 0, 0)
   }


### PR DESCRIPTION
Fixes #286.

The scratch canvas the effect composites through is only reset when the target is resized, so on a steady-size movie it's never cleared. `drawImage` composites source-over, so the previous transformed frame survives wherever the current one is transparent and gets copied back onto the target — the trail @keiddzz reported.

This clears the scratch canvas before compositing, resetting the transform to identity first so the clear isn't mapped through the last frame's matrix. That reset replaces the one that was at the end of `apply`, whose arguments were in the wrong order: `setTransform(1, 0, 0, 0, 1, 0)` has `d = 0`, so it was degenerate rather than identity.

Added a unit test that applies the effect over two frames and asserts the old position is empty — it fails on master and passes here. I also reproduced @keiddzz's setup end to end (an `Image` layer with a keyframed matrix, rendered across four frames) and confirmed the trail is gone. Existing unit, smoke and integration suites all pass.
